### PR TITLE
Fix for sending templates

### DIFF
--- a/src/main/java/com/cribbstechnologies/clients/mandrill/model/ServiceMethods.java
+++ b/src/main/java/com/cribbstechnologies/clients/mandrill/model/ServiceMethods.java
@@ -12,6 +12,7 @@ public class ServiceMethods {
 	
 	public class Messages {
 		public static final String SEND = "messages/send.json";
+		public static final String SEND_TEMPLATE = "messages/send-template.json";
 	}
 	
 	public class Tags {

--- a/src/main/java/com/cribbstechnologies/clients/mandrill/request/MandrillMessagesRequest.java
+++ b/src/main/java/com/cribbstechnologies/clients/mandrill/request/MandrillMessagesRequest.java
@@ -35,7 +35,7 @@ public class MandrillMessagesRequest {
 	
 	public SendMessageResponse sendTemplatedMessage(MandrillTemplatedMessageRequest templateMessage) throws RequestFailedException {
 		SendMessageResponse response = new SendMessageResponse();
-		response.setList(((BaseMandrillAnonymousListResponse<MessageResponse>) request.postRequest(templateMessage, ServiceMethods.Messages.SEND, SendMessageResponse.class, messageResponseListReference)).getList());
+		response.setList(((BaseMandrillAnonymousListResponse<MessageResponse>) request.postRequest(templateMessage, ServiceMethods.Messages.SEND_TEMPLATE, SendMessageResponse.class, messageResponseListReference)).getList());
 		return response;
 	}
 


### PR DESCRIPTION
It was not possible to send templates because the incorrect REST service URL was used. This fix changes the URL for templated message sends.
