### PR TITLE
Send Template API request should hit /messages/send-template.json

### DIFF
--- a/src/main/java/com/cribbstechnologies/clients/mandrill/model/ServiceMethods.java
+++ b/src/main/java/com/cribbstechnologies/clients/mandrill/model/ServiceMethods.java
@@ -1,7 +1,7 @@
 package com.cribbstechnologies.clients.mandrill.model;
 
 public class ServiceMethods {
-	
+
 	public class Users {
 		public static final String PING = "users/ping.json";
 		public static final String INFO = "users/info.json";
@@ -9,17 +9,18 @@ public class ServiceMethods {
 		public static final String DISABLE_SENDER = "users/disable-sender.json";
 		public static final String VERIFY_SENDER = "users/verify-sender.json";
 	}
-	
+
 	public class Messages {
 		public static final String SEND = "messages/send.json";
+		public static final String SEND_TEMPLATE = "messages/send-template.json";
 	}
-	
+
 	public class Tags {
 		public static final String LIST = "tags/list.json";
 		public static final String TIME_SERIES = "tags/time-series.json";
 		public static final String ALL_TIME_SERIES = "tags/all-time-series.json";
 	}
-	
+
 	public class Urls {
 		public static final String LIST = "urls/list.json";
 		public static final String SEARCH = "urls/search.json";

--- a/src/main/java/com/cribbstechnologies/clients/mandrill/request/MandrillMessagesRequest.java
+++ b/src/main/java/com/cribbstechnologies/clients/mandrill/request/MandrillMessagesRequest.java
@@ -35,7 +35,7 @@ public class MandrillMessagesRequest {
 	
 	public SendMessageResponse sendTemplatedMessage(MandrillTemplatedMessageRequest templateMessage) throws RequestFailedException {
 		SendMessageResponse response = new SendMessageResponse();
-		response.setList(((BaseMandrillAnonymousListResponse<MessageResponse>) request.postRequest(templateMessage, ServiceMethods.Messages.SEND, SendMessageResponse.class, messageResponseListReference)).getList());
+		response.setList(((BaseMandrillAnonymousListResponse<MessageResponse>) request.postRequest(templateMessage, ServiceMethods.Messages.SEND_TEMPLATE, SendMessageResponse.class, messageResponseListReference)).getList());
 		return response;
 	}
 


### PR DESCRIPTION
The Send Template API call was hitting the wrong URL and was
therefore not including any content in the sent email. This
patch corrects the issue by modifying the
ServiceMethods.Messages class to include a property pointing at
the correct endpoint.
