### PR TITLE
Adding merge_vars to MandrillMessage

### DIFF
--- a/src/main/java/com/cribbstechnologies/clients/mandrill/model/MandrillMessage.java
+++ b/src/main/java/com/cribbstechnologies/clients/mandrill/model/MandrillMessage.java
@@ -18,7 +18,8 @@ public class MandrillMessage {
 	private String[] google_analytics_domains = new String[0];
 	private String[] google_analytics_campaign = new String[0];
     private List<MergeVar> global_merge_vars;
-	
+    List<MessageMergeVars> merge_vars;
+
 	private Map<String, String> headers;
 	
 	public String getSubject() {
@@ -132,5 +133,13 @@ public class MandrillMessage {
 
     public void setGlobal_merge_vars(List<MergeVar> global_merge_vars) {
         this.global_merge_vars = global_merge_vars;
+    }
+
+    public List<MessageMergeVars> getMerge_vars() {
+        return merge_vars;
+    }
+
+    public void setMerge_vars(List<MessageMergeVars> merge_vars) {
+        this.merge_vars = merge_vars;
     }
 }

--- a/src/main/java/com/cribbstechnologies/clients/mandrill/model/MessageMergeVars.java
+++ b/src/main/java/com/cribbstechnologies/clients/mandrill/model/MessageMergeVars.java
@@ -1,0 +1,24 @@
+package com.cribbstechnologies.clients.mandrill.model;
+
+import java.util.List;
+
+public class MessageMergeVars {
+    private String rcpt;
+    private List<MergeVar> vars;
+
+    public String getRcpt() {
+        return rcpt;
+    }
+
+    public void setRcpt(String rcpt) {
+        this.rcpt = rcpt;
+    }
+
+    public List<MergeVar> getVars() {
+        return vars;
+    }
+
+    public void setVars(List<MergeVar> vars) {
+        this.vars = vars;
+    }
+}

--- a/src/test/java/com/cribbstechnologies/clients/mandrill/request/MandrillRESTRequestTest.java
+++ b/src/test/java/com/cribbstechnologies/clients/mandrill/request/MandrillRESTRequestTest.java
@@ -262,6 +262,7 @@ public class MandrillRESTRequestTest {
 		sb.append(",\"google_analytics_domains\":[]");
 		sb.append(",\"google_analytics_campaign\":[]");
         sb.append(",\"global_merge_vars\":null");
+        sb.append(",\"merge_vars\":null");
 		sb.append(",\"headers\":{\"headerName\":\"headerValue\"},");
 		sb.append("\"html\":\"Test html\"");
 		sb.append("}}");


### PR DESCRIPTION
merge_vars - per-recipient merge variables, which override global merge variables with the same name.
