### PR TITLE
Encode Requests with UTF-8 to support German Umlauts in requests 

### DIFF
--- a/src/main/java/com/cribbstechnologies/clients/mandrill/request/MandrillRESTRequest.java
+++ b/src/main/java/com/cribbstechnologies/clients/mandrill/request/MandrillRESTRequest.java
@@ -42,7 +42,7 @@ public class MandrillRESTRequest {
 			request.setKey(config.getApiKey());
 			HttpPost postRequest = new HttpPost(config.getServiceUrl() + serviceMethod);
 			String postData = getPostData(request);
-			StringEntity input = new StringEntity(postData);
+			StringEntity input = new StringEntity(postData, "UFT-8");
 			input.setContentType("application/json");
 			postRequest.setEntity(input);
 			


### PR DESCRIPTION
if i send have e.g an Recipient like this:

new MandrillRecipient("Andreas Lüdeke", "mail@bla.de")

mandrill returns a HTTP Status 500 wit message "you must specify a key value". This happens due to the fact that the ü is not properly encoded within the StringEntity. By Specifying the correct Encoding it works properly
