### PR TITLE
Let Git ignore Eclipse project files and the 'target' folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.classpath
+.project
+.settings
+target
+


### PR DESCRIPTION
Better ignore files that are generated by the build and IDE so that they don't get checked in accidentally.
