### PR TITLE
Support complex merge_vars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,11 +8,11 @@
 	<!-- </parent> -->
 	<groupId>com.cribbstechnologies.clients</groupId>
 	<artifactId>mandrillClient</artifactId>
-	<version>1.0.2</version>
+	<version>1.0.1.FIXMERGEVARS</version>
 	<packaging>jar</packaging>
 	<name>Java Mandrill Wrapper</name>
 	<description>A Java wrapper for Mandrill</description>
-	<url>https://github.com/cribbstechnologies/Java-Mandrill-Wrapper</url>
+	<url>https://github.com/stanislasbonifetto/Java-Mandrill-Wrapper.git</url>
 
 	<developers>
 		<developer>
@@ -27,9 +27,9 @@
 	</developers>
 
 	<scm>
-		<url>scm:git:git@github.com:cribbstechnologies/Java-Mandrill-Wrapper.git</url>
-		<connection>scm:git:git@github.com:cribbstechnologies/Java-Mandrill-Wrapper.git</connection>
-		<developerConnection>scm:git:git@github.com:cribbstechnologies/Java-Mandrill-Wrapper.git
+		<url>scm:git:git@github.com:stanislasbonifetto/Java-Mandrill-Wrapper.git</url>
+		<connection>scm:git:git@github.com:stanislasbonifetto/Java-Mandrill-Wrapper.git</connection>
+		<developerConnection>scm:git:git@github.com:stanislasbonifetto/Java-Mandrill-Wrapper.git
     </developerConnection>
 	</scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<packaging>jar</packaging>
 	<name>Java Mandrill Wrapper</name>
 	<description>A Java wrapper for Mandrill</description>
-	<url>https://github.com/cribbstechnologies/Java-Mandrill-Wrapper.git</url>
+	<url>https://github.com/cribbstechnologies/Java-Mandrill-Wrapper</url>
 
 	<developers>
 		<developer>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<packaging>jar</packaging>
 	<name>Java Mandrill Wrapper</name>
 	<description>A Java wrapper for Mandrill</description>
-	<url>https://github.com/stanislasbonifetto/Java-Mandrill-Wrapper.git</url>
+	<url>https://github.com/cribbstechnologies/Java-Mandrill-Wrapper.git</url>
 
 	<developers>
 		<developer>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<!-- </parent> -->
 	<groupId>com.cribbstechnologies.clients</groupId>
 	<artifactId>mandrillClient</artifactId>
-	<version>1.0.1</version>
+	<version>1.0.2</version>
 	<packaging>jar</packaging>
 	<name>Java Mandrill Wrapper</name>
 	<description>A Java wrapper for Mandrill</description>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<!-- </parent> -->
 	<groupId>com.cribbstechnologies.clients</groupId>
 	<artifactId>mandrillClient</artifactId>
-	<version>1.0.1.FIXMERGEVARS</version>
+	<version>1.0.1</version>
 	<packaging>jar</packaging>
 	<name>Java Mandrill Wrapper</name>
 	<description>A Java wrapper for Mandrill</description>
@@ -27,9 +27,9 @@
 	</developers>
 
 	<scm>
-		<url>scm:git:git@github.com:stanislasbonifetto/Java-Mandrill-Wrapper.git</url>
-		<connection>scm:git:git@github.com:stanislasbonifetto/Java-Mandrill-Wrapper.git</connection>
-		<developerConnection>scm:git:git@github.com:stanislasbonifetto/Java-Mandrill-Wrapper.git
+		<url>scm:git:git@github.com:cribbstechnologies/Java-Mandrill-Wrapper.git</url>
+		<connection>scm:git:git@github.com:cribbstechnologies/Java-Mandrill-Wrapper.git</connection>
+		<developerConnection>scm:git:git@github.com:cribbstechnologies/Java-Mandrill-Wrapper.git
     </developerConnection>
 	</scm>
 

--- a/src/main/java/com/cribbstechnologies/clients/mandrill/model/MergeVar.java
+++ b/src/main/java/com/cribbstechnologies/clients/mandrill/model/MergeVar.java
@@ -10,7 +10,7 @@ package com.cribbstechnologies.clients.mandrill.model;
 public class MergeVar {
     private String name;
     private Object content;
-    public MergeVar(String name, String content) {
+    public MergeVar(String name, Object content) {
         this.name = name;
         this.content = content;
     }

--- a/src/main/java/com/cribbstechnologies/clients/mandrill/model/MergeVar.java
+++ b/src/main/java/com/cribbstechnologies/clients/mandrill/model/MergeVar.java
@@ -9,7 +9,7 @@ package com.cribbstechnologies.clients.mandrill.model;
  */
 public class MergeVar {
     private String name;
-    private String content;
+    private Object content;
     public MergeVar(String name, String content) {
         this.name = name;
         this.content = content;
@@ -22,11 +22,11 @@ public class MergeVar {
         this.name = name;
     }
 
-    public String getContent() {
+    public Object getContent() {
         return content;
     }
 
-    public void setContent(String content) {
+    public void setContent(Object content) {
         this.content = content;
     }
 }


### PR DESCRIPTION
Change the class MergeVar to support not only string in content but complex object.

The API mandrill support complex object in content.
https://mandrillapp.com/api/docs/messages.JSON.html#method=send-template
